### PR TITLE
Adjust function signature style

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,11 +522,13 @@ func reticulateSplines(spline: [Double]) -> Bool {
 }
 ```
 
-For functions with long signatures, add line breaks at appropriate points and add an extra indent on subsequent lines:
+For functions with long signatures, add line breaks after each parameter, indent all parameters so they appear under the first one in a column:
 
 ```swift
-func reticulateSplines(spline: [Double], adjustmentFactor: Double,
-    translateConstant: Int, comment: String) -> Bool {
+func reticulateSplines(spline: [Double], 
+                       adjustmentFactor: Double,
+                       translateConstant: Int, 
+                       comment: String) -> Bool {
     // reticulate code goes here
 }
 ```


### PR DESCRIPTION
Motivation:
Arguably cleaner, more readable, prettier. In the mean time will look ugly if there's a lot of parameters and will discourage this practice.