### PR TITLE
Adjust let/var selection rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,9 +604,7 @@ In Sprite Kit code, use `CGFloat` if it makes the code more succinct by avoiding
 
 ### Constants
 
-Constants are defined using the `let` keyword, and variables with the `var` keyword. Always use `let` instead of `var` if the value of the variable will not change.
-
-**Tip:** A good technique is to define everything using `let` and only change it to `var` if the compiler complains!
+Constants are defined using the `let` keyword, and variables with the `var` keyword. Always use `let` instead of `var` if the value of the variable is not intended to be changed or changes to this variable will not be properly handled.
 
 You can define constants on a type rather than on an instance of that type using type properties. To declare a type property as a constant simply use `static let`. Type properties declared in this way are generally preferred over global constants because they are easier to distinguish from instance properties. Example:
 


### PR DESCRIPTION
Motivation:
Clearer variable/constants purpose; cleaner customization options when configuring modules of other teammates; fewer recompilations due to changes to let/var